### PR TITLE
chore: add Python venv names to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -365,3 +365,12 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/


### PR DESCRIPTION
I personally use .venv everywhere but the longer list is taken from [here](https://github.com/github/gitignore/blob/cdd9e946da421758c6f42c427c7bc65c8326155d/Python.gitignore#L107-L114).