### PR TITLE
Fix default working-directory

### DIFF
--- a/.github/workflows/AIForOrcas.Client.Web.yaml
+++ b/.github/workflows/AIForOrcas.Client.Web.yaml
@@ -28,7 +28,7 @@ env:
 
 defaults:
   run:
-    working-directory: ${{ env.WORKING_DIR }}
+    working-directory: ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web
 
 jobs:
   build:

--- a/.github/workflows/AIForOrcas.Server.yaml
+++ b/.github/workflows/AIForOrcas.Server.yaml
@@ -26,7 +26,7 @@ env:
 
 defaults:
   run:
-    working-directory: ${{ env.WORKING_DIR }}
+    working-directory: ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server
 
 jobs:
   build:


### PR DESCRIPTION
The `act` harness allows the default working directory to be an environment variable. Github Actions proper does not seem to.