### PR TITLE
patch dashboard/user metrics pages to improve page load time

### DIFF
--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Dashboard.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Dashboard.razor.cs
@@ -18,7 +18,7 @@ namespace AIForOrcas.Client.Web.Pages
 		private Metrics metrics = null;
 
 		private MetricsFilterDTO filterOptions =
-			new MetricsFilterDTO() { Timeframe = "all" };
+			new MetricsFilterDTO() { Timeframe = "1m" };
 
 		private string messageStyle = "d-none";
 		private string message = string.Empty;

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/User/UserActivity.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/User/UserActivity.razor.cs
@@ -22,7 +22,7 @@ namespace AIForOrcas.Client.Web.Pages.User
 		private ModeratorMetrics metrics = null;
 
 		private ModeratorMetricsFilterDTO filterOptions =
-			new ModeratorMetricsFilterDTO() { Timeframe = "all" };
+			new ModeratorMetricsFilterDTO() { Timeframe = "1m" };
 
 		private string messageStyle = "d-none";
 		private string message = string.Empty;


### PR DESCRIPTION
Change default dashboard page `filterOptions.Timeframe` to last month (`"1m"`) so that the page loads faster. The current default is `"all"` which is prohibitively large (3k+ detections).

Valid dropdown options are defined in [MetricsFilterComponent.razor](https://github.com/orcasound/aifororcas-livesystem/blob/main/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/MetricsFilterComponent.razor)

I'm assuming that CD is already setup to deploy this after it's merged, else let me know what i'd need to do - thanks!