### PR TITLE
New Tab for Dashboard/User Metrics Tag Links

### DIFF
--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Dashboard.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Dashboard.razor
@@ -85,7 +85,7 @@
 									<ul class="list-inline">
 										@foreach (var link in entry.Ids)
 										{
-											<li class="list-inline-item"><a href="/detections/detection/@link">@link</a></li>
+											<li class="list-inline-item"><a href="/detections/detection/@link" target="_blank">@link</a></li>
 										}
 									</ul>
 								}

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/SingleDetection.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/SingleDetection.razor
@@ -1,5 +1,6 @@
 ﻿@page "/detections/detection/{id}"
 
+<PageTitle>Detection - @Id</PageTitle>
 <PageHeadingComponent Title="Detection" />
 
 @if (detection == null)

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/User/UserActivity.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/User/UserActivity.razor
@@ -86,7 +86,7 @@
 									<ul class="list-inline">
 										@foreach (var link in entry.Ids)
 										{
-											<li class="list-inline-item"><a href="/detections/detection/@link">@link</a></li>
+											<li class="list-inline-item"><a href="/detections/detection/@link" target="_blank">@link</a></li>
 										}
 									</ul>
 								}

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/_Host.cshtml
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/_Host.cshtml
@@ -1,6 +1,7 @@
 ﻿@page "/"
 @namespace AIForOrcas.Client.Web.Pages
 @using AIForOrcas.Client.Web
+@using Microsoft.AspNetCore.Components.Web
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @{
 	Layout = null;
@@ -26,6 +27,7 @@
 <body>
 	<app>
 		<component type="typeof(App)" render-mode="Server" />
+		<component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
 	</app>
 
 	<div id="blazor-error-ui">


### PR DESCRIPTION
* Dashboard Tag list updated so that clicking a detection link opens a new tab so that users will not have to re-load the dashboard up close. Tab title includes the ID of the detection being viewed.
* Also added this to the User Activity/Metrics page.