### PR TITLE
Rename Haro Strait/Straight to Orcasound Lab

### DIFF
--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/appsettings.Development.json
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/appsettings.Development.json
@@ -9,7 +9,7 @@
   },
   "AppSettings": {
     "APIUrl": "https://apisitename.azurewebsites.net/",
-    "Locations": [ "Bush Point", "Haro Strait", "Port Townsend" ],
+    "Locations": [ "Bush Point", "Orcasound Lab", "Port Townsend" ],
     "AzureAd": {
       "Instance": "https://login.microsoftonline.com/",
       "Domain": "outlookdomain.onmicrosoft.com",

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/appsettings.Development.json
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/appsettings.Development.json
@@ -9,7 +9,7 @@
   },
   "AppSettings": {
     "APIUrl": "https://apisitename.azurewebsites.net/",
-    "Locations": [ "Bush Point", "Orcasound Lab", "Port Townsend" ],
+    "Locations": [ "Bush Point", "MaST Center", "North San Juan Channel", "Orcasound Lab", "Point Robinson", "Port Townsend", "Sunset Bay" ],
     "AzureAd": {
       "Instance": "https://login.microsoftonline.com/",
       "Domain": "outlookdomain.onmicrosoft.com",

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/appsettings.json
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/appsettings.json
@@ -23,7 +23,7 @@
   "AllowedHosts": "*",
   "AppSettings": {
     "APIUrl": "https://apisitename.azurewebsites.net/",
-    "Locations": [ "Bush Point", "Haro Strait", "Port Townsend" ],
+    "Locations": [ "Bush Point", "Orcasound Lab", "Port Townsend" ],
     "AzureAd": {
       "Instance": "https://login.microsoftonline.com/",
       "Domain": "outlookdomain.onmicrosoft.com",

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/appsettings.json
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/appsettings.json
@@ -23,7 +23,7 @@
   "AllowedHosts": "*",
   "AppSettings": {
     "APIUrl": "https://apisitename.azurewebsites.net/",
-    "Locations": [ "Bush Point", "Orcasound Lab", "Port Townsend" ],
+    "Locations": [ "Bush Point", "MaST Center", "North San Juan Channel", "Orcasound Lab", "Point Robinson", "Port Townsend", "Sunset Bay" ],
     "AzureAd": {
       "Instance": "https://login.microsoftonline.com/",
       "Domain": "outlookdomain.onmicrosoft.com",

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/API/Detections/DetectionQueryParameters.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/API/Detections/DetectionQueryParameters.cs
@@ -44,7 +44,7 @@ namespace AIForOrcas.DTO.API
 		public DateTime? DateTo { get; set; }
 
 		/// <summary>
-		/// Location of the hydrophone (all, Haro Straight, Port Townsend, etc.).
+		/// Location of the hydrophone (all, Orcasound Lab, Port Townsend, etc.).
 		/// </summary>
 		/// <example>all</example>
 		public string Location { get; set; } = "all";

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/API/Detections/Location.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/API/Detections/Location.cs
@@ -8,7 +8,7 @@
 		/// <summary>
 		/// Name of the hydrophone location.
 		/// </summary>
-		/// <example>Haro Strait</example>
+		/// <example>Orcasound Lab</example>
 		public string Name { get; set; }
 
 		/// <summary>

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/DetectionOrchestrationServiceTests/Default.RetrieveFilteredDetectionsAsync.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/DetectionOrchestrationServiceTests/Default.RetrieveFilteredDetectionsAsync.cs
@@ -21,7 +21,7 @@ namespace OrcaHello.Web.Api.Tests.Unit.Services
                 Page = 1,
                 PageSize = 10,
                 State = "Positive",
-                Location = "Haro Straight",
+                Location = "Orcasound Lab",
                 SortBy = "timestamp",
                 SortOrder = "DESC"
             };

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/MetadataServiceTests/Default.RetrievePaginatedMetadataAsync.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/MetadataServiceTests/Default.RetrievePaginatedMetadataAsync.cs
@@ -23,7 +23,7 @@
             DateTime toDate = DateTime.Now.AddDays(1);
 
             var result = await _metadataService.
-                RetrievePaginatedMetadataAsync("Positive", fromDate, toDate, "timestamp", true, "Haro Straight", 1, 10);
+                RetrievePaginatedMetadataAsync("Positive", fromDate, toDate, "timestamp", true, "Orcasound Lab", 1, 10);
 
             Assert.AreEqual(expectedResult.PaginatedRecords.Count(), result.QueryableRecords.Count());
 
@@ -54,7 +54,7 @@
             DateTime toDate = DateTime.Now.AddDays(1);
 
             var result = await _metadataService.
-                RetrievePaginatedMetadataAsync("Positive", fromDate, toDate, "timestamp", true, "Haro Straight", -1, -10);
+                RetrievePaginatedMetadataAsync("Positive", fromDate, toDate, "timestamp", true, "Orcasound Lab", -1, -10);
 
             Assert.AreEqual(expectedResult.PaginatedRecords.Count(), result.QueryableRecords.Count());
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Models/Metadatas/Metadata.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Models/Metadatas/Metadata.cs
@@ -23,7 +23,7 @@
         /// <summary>
         /// The name of the hydrophone where the metadata was collected.
         /// </summary>
-        /// <example>Haro Strait</example>
+        /// <example>Orcasound Lab</example>
         [JsonProperty("locationName", NullValueHandling = NullValueHandling.Ignore)]
         public string LocationName { get; set; }
 
@@ -119,7 +119,7 @@
         /// <summary>
         /// Name of the hydrophone location.
         /// </summary>
-        /// <example>Haro Strait</example>
+        /// <example>Orcasound Lab</example>
         [JsonProperty("name", NullValueHandling = NullValueHandling.Ignore)]
         public string Name { get; set; }
 

--- a/ModeratorFrontEnd/schema/example_v2.json
+++ b/ModeratorFrontEnd/schema/example_v2.json
@@ -1,14 +1,14 @@
  {
         "id": "000000000-000000000-00000000-00000000000", // Guid
         "state": "Unreviewed", // State of the review (Unreviewed, Positive, Negative, Unknown)
-        "locationName": "Haro Strait", // the name of the location (does duplicate name in location below)
+        "locationName": "Orcasound Lab", // the name of the location (does duplicate name in location below)
         "audioUri": "https://livemlaudiospecstorage.blob.core.windows.net/audiowavs/rpi_orcasound_lab_2020_09_30_03_51_56_PDT.wav", // string
         "imageUri": "https://livemlaudiospecstorage.blob.core.windows.net/spectrogramspng/rpi_orcasound_lab_2020_09_30_03_51_56_PDT.png", // string
         "timestamp": "2020-09-30T10:51:56.057346Z", // ISO format - UTC
         "whaleFoundConfidence": 88.55000000000001, // double
         "location": {
             "id": "rpi_orcasound_lab",
-            "name": "Haro Strait",
+            "name": "Orcasound Lab",
             "longitude": -123.2166658,
             "latitude": 48.5499978
         },


### PR DESCRIPTION
* Rename Haro Strait/Straight to Orcasound Lab
* Add additional nodes that were missing from the combobox to select from

Fixes #145
Fixes #146

This is a temporary workaround.  The correct fix is to get the full list from [live.orcasound.net/api/json/feeds](https://live.orcasound.net/api/json/feeds)