### PR TITLE
Upgrade ModeratorFrontEnd to .NET 8.0 (LTS)

### DIFF
--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/OrcaHello.Web.Api.Tests.Unit.csproj
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/OrcaHello.Web.Api.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/OrcaHello.Web.Api.csproj
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/OrcaHello.Web.Api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>84e68496-647e-43b5-9863-dc97f799ecc9</UserSecretsId>

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/OrcaHello.Web.UI.Tests.Unit.csproj
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/OrcaHello.Web.UI.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/OrcaHello.Web.UI.csproj
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/OrcaHello.Web.UI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>43df5476-1126-4a11-8afe-2fd7274b0b32</UserSecretsId>


### PR DESCRIPTION
.NET 7.0 is deprecated and one can no longer create App Services in Azure targeting it.

See https://devblogs.microsoft.com/dotnet/dotnet-7-end-of-support/