### PR TITLE
fixed small error in the global threshold calculation

### DIFF
--- a/InferenceSystem/src/model/fastai_inference.py
+++ b/InferenceSystem/src/model/fastai_inference.py
@@ -168,7 +168,7 @@ class FastAIModel():
             local_confidences=list(submission['confidence'])
         )
 
-        result_json['global_prediction'] = int(sum(result_json["local_predictions"]) > self.min_num_positive_calls_threshold)
+        result_json['global_prediction'] = int(sum(result_json["local_predictions"]) >= self.min_num_positive_calls_threshold)
         result_json['global_confidence'] = submission.loc[(submission['confidence'] > self.threshold), 'confidence'].mean()*100
         if pd.isnull(result_json["global_confidence"]):
             result_json["global_confidence"] = 0


### PR DESCRIPTION
Addresses [https://github.com/orcasound/aifororcas-livesystem/issues/219](https://github.com/orcasound/aifororcas-livesystem/issues/219)

The number of positive calls had to be greater than the `min_num_positive_calls_threshold` to trigger a global prediction