### PR TITLE
Update NotificationSystem docs for .NET 8.0

### DIFF
--- a/NotificationSystem/README.md
+++ b/NotificationSystem/README.md
@@ -128,7 +128,9 @@ Create local.settings.json in the current directory (NotificationSystem) using t
         "aifororcasmetadatastore_DOCUMENTDB": "<cosmos db connection string>",
         "AWS_ACCESS_KEY_ID": "<AWS Access Key>",
         "AWS_SECRET_ACCESS_KEY": "<AWS Secret Key>",
-        "SenderEmail": "<email address>"
+        "SenderEmail": "<email address>",
+        "FUNCTIONS_WORKER_RUNTIME": "dotnet",
+        "FUNCTIONS_INPROC_NET8_ENABLED": "1"
     }
 }
 ```


### PR DESCRIPTION
PR #247 upgraded NotificationSystem to .NET 8.0 but didn't update the README.md to match.
This PR updates the doc accordingly.