### PR TITLE
Let dependabot skip major version changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,9 @@ updates:
       actions:
         patterns:
           - "*"
+    labels:
+      - "dependencies"
+      - "notification system"
     ignore:
       - dependency-name: "*"
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,7 @@ updates:
       actions:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
Major version changes are by definition breaking changes and dependabot cannot change the things they break (e.g., the reason PR #273 failed tests). Non-major changes are backwards compatible and safe to update with dependabot.

This PR also adds the "notification system" label to any dependabot PR's against NotificationSystem code.

Leave breaking changes for issue #152