### PR TITLE
[BugFix] Fix deserialization bug -  SendSubscriberEmail

### DIFF
--- a/NotificationSystem/NotificationSystem/SendSubscriberEmail.cs
+++ b/NotificationSystem/NotificationSystem/SendSubscriberEmail.cs
@@ -78,7 +78,8 @@ namespace NotificationSystem
                 if (message == null || string.IsNullOrEmpty(message.MessageText))
                     break;
 
-                messagesJson.Add(JsonConvert.DeserializeObject<JObject>(message.MessageText));
+                var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(message.MessageText));
+                messagesJson.Add(JsonConvert.DeserializeObject<JObject>(decoded));
                 await queueClient.DeleteMessageAsync(message.MessageId, message.PopReceipt);
             }
 


### PR DESCRIPTION
The Azure Function for SendSubscriberEmail is failing.
This is due to a deserialization bug. SendSubscriberEmail pulls messages from a Storage Queue. We write objects into the Queue via DbToQueue Azure Function.

When putting items in the queue, we encode as base64
`await queueClient.SendMessageAsync(StringHelpers.Base64Encode(item.GetRawText()));`

When taking things out of the queue we currently deserialize without decoding back to the original JSON payload. This PR fixes the issue.
`messagesJson.Add(JsonConvert.DeserializeObject<JObject>(message.MessageText));`


See metrics/logs below:

<img width="1043" height="480" alt="image" src="https://github.com/user-attachments/assets/48ee5837-df51-4420-8c96-f6290c86d8a4" />

`Exception while executing function: Functions.SendSubscriberEmail <--- Result: Failure Exception: Unexpected character encountered while parsing value: e. Path '', line 0, position 0. Stack: at Newtonsoft.Json.JsonTextReader.ParseValue() at Newtonsoft.Json.JsonTextReader.Read() at Newtonsoft.Json.JsonReader.ReadForType(JsonContract contract, Boolean hasConverter) at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent) at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType) at Newtonsoft.Json.JsonConvert.DeserializeObject(String value, Type type, JsonSerializerSettings settings) at NotificationSystem.SendSubscriberEmail.CreateBody(QueueClient queueClient) in /home/runner/work/aifororcas-livesystem/aifororcas-livesystem/NotificationSystem/NotificationSystem/SendSubscriberEmail.cs:line 81 at NotificationSystem.SendSubscriberEmail.Run(String timerInfo, TableClient tableClient) in /home/runner/work/aifororcas-livesystem/aifororcas-livesystem/NotificationSystem/NotificationSystem/SendSubscriberEmail.cs:line 51 at NotificationSystem.DirectFunctionExecutor.ExecuteAsync(FunctionContext context) in /home/runner/work/aifororcas-livesystem/aifororcas-livesystem/NotificationSystem/NotificationSystem/obj/Release/net8.0/Microsoft.Azure.Functions.Worker.Sdk.Generators/Microsoft.Azure.Functions.Worker.Sdk.Generators.FunctionExecutorGenerator/GeneratedFunctionExecutor.g.cs:line 78 at Microsoft.Azure.Functions.Worker.OutputBindings.OutputBindingsMiddleware.Invoke(FunctionContext context, FunctionExecutionDelegate next) in D:\a\_work\1\s\src\DotNetWorker.Core\OutputBindings\OutputBindingsMiddleware.cs:line 13 at Microsoft.Azure.Functions.Worker.FunctionsApplication.InvokeFunctionAsync(FunctionContext context) in D:\a\_work\1\s\src\DotNetWorker.Core\FunctionsApplication.cs:line 96 at Microsoft.Azure.Functions.Worker.Handlers.InvocationHandler.InvokeAsync(InvocationRequest request) in D:\a\_work\1\s\src\DotNetWorker.Grpc\Handlers\InvocationHandler.cs:line 89`