### PR TITLE
Add a tool to copy history of detections to Orcasite

### DIFF
--- a/NotificationSystem/NotificationSystem.sln
+++ b/NotificationSystem/NotificationSystem.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NotificationSystem.Tests.Un
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NotificationSystem.Tests.Integration", "NotificationSystem.Tests.Integration\NotificationSystem.Tests.Integration.csproj", "{B8C3D456-789A-2B3C-9876-123456789ABC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PostBackfillToOrcasite", "PostBackfillToOrcasite\PostBackfillToOrcasite.csproj", "{A13110FD-D49E-4906-85FB-E5A969BEB417}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{B8C3D456-789A-2B3C-9876-123456789ABC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B8C3D456-789A-2B3C-9876-123456789ABC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B8C3D456-789A-2B3C-9876-123456789ABC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A13110FD-D49E-4906-85FB-E5A969BEB417}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A13110FD-D49E-4906-85FB-E5A969BEB417}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A13110FD-D49E-4906-85FB-E5A969BEB417}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A13110FD-D49E-4906-85FB-E5A969BEB417}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NotificationSystem/NotificationSystem/Models/OrcasiteHelper.cs
+++ b/NotificationSystem/NotificationSystem/Models/OrcasiteHelper.cs
@@ -93,12 +93,15 @@ namespace NotificationSystem.Models
         /// <returns>A task that represents the asynchronous operation</returns>
         public async Task InitializeAsync()
         {
-            _orcasiteApiKey = Environment.GetEnvironmentVariable("ORCASITE_APIKEY");
-            _orcasiteHostname = Environment.GetEnvironmentVariable("ORCASITE_HOSTNAME") ?? "beta.orcasound.net";
-            _orcasiteFeedsArray = await GetDataArrayAsync(OrcasiteGetFeedsUri);
             if (_orcasiteFeedsArray == null)
             {
-                _logger.LogError("Failed to retrieve orcasite feeds.");
+                _orcasiteApiKey = Environment.GetEnvironmentVariable("ORCASITE_APIKEY");
+                _orcasiteHostname = Environment.GetEnvironmentVariable("ORCASITE_HOSTNAME") ?? "beta.orcasound.net";
+                _orcasiteFeedsArray = await GetDataArrayAsync(OrcasiteGetFeedsUri);
+                if (_orcasiteFeedsArray == null)
+                {
+                    _logger.LogError("Failed to retrieve orcasite feeds.");
+                }
             }
         }
 

--- a/NotificationSystem/PostBackfillToOrcasite/PostBackfillToOrcasite.csproj
+++ b/NotificationSystem/PostBackfillToOrcasite/PostBackfillToOrcasite.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.53.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NotificationSystem\NotificationSystem.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/NotificationSystem/PostBackfillToOrcasite/Program.cs
+++ b/NotificationSystem/PostBackfillToOrcasite/Program.cs
@@ -1,0 +1,98 @@
+﻿// This is a console tool to post the history
+// of OrcaHello detections to Orcasite, for data
+// analysis purposes.
+
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using NotificationSystem;
+using NotificationSystem.Models;
+using System.Text.Json;
+
+namespace PostBackfillToOrcasite
+{
+    class Program
+    {
+        static async Task Main(string[] args)
+        {
+            if (args.Length < 1)
+            {
+                Console.WriteLine("""
+Usage: PostBackfillToOrcasite <ISO8601 timestamp>
+
+The following environment variables must be set:
+ * aifororcasmetadatastore_DOCUMENTDB
+     Must be set to the OrcaHello cosmosdb connection string.
+ * ORCASITE_APIKEY
+     Must be set to the API key to allow Orcasite posts.
+ * ORCASITE_HOSTNAME
+     Should be set to the Orcasite hostname.
+     Defaults to beta.orcasound.net if not present.
+
+Example:
+    PostBackfillToOrcasite 2025-07-30T00:00:00Z
+""");
+                return;
+            }
+            if (!DateTime.TryParse(args[0], out DateTime startTime))
+            {
+                Console.WriteLine("Invalid timestamp format. Use ISO 8601 (e.g., 2023-01-01T00:00:00Z)");
+                return;
+            }
+            string isoTimestamp = startTime.ToString("o"); // ISO 8601 format
+
+            // Set up Orcasite client.
+            var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+                builder.SetMinimumLevel(LogLevel.Information);
+            });
+            var helperLogger = loggerFactory.CreateLogger<OrcasiteHelper>();
+            var httpClient = new HttpClient();
+            var orcasiteHelper = new OrcasiteHelper(helperLogger, httpClient);
+            await orcasiteHelper.InitializeAsync();
+            var functionLogger = loggerFactory.CreateLogger<PostToOrcasite>();
+            var postToOrcasite = new PostToOrcasite(orcasiteHelper, functionLogger);
+
+            // Set up Cosmos DB client.
+            string connectionString = Environment.GetEnvironmentVariable("aifororcasmetadatastore_DOCUMENTDB")
+                ?? throw new InvalidOperationException("aifororcasmetadatastore_DOCUMENTDB not set");
+            string databaseName = "predictions";
+            string containerName = "metadata";
+            var client = new CosmosClient(connectionString);
+            var container = client.GetContainer(databaseName, containerName);
+
+            // Start reading OrcaHello detections.
+            Console.WriteLine($"Querying for detections with timestamp after {isoTimestamp}");
+            var query = container.GetItemQueryIterator<JObject>($"SELECT * FROM c WHERE c.timestamp > '{isoTimestamp}'");
+            int count = 0;
+            int successes = 0;
+            while (query.HasMoreResults)
+            {
+                foreach (JObject item in await query.ReadNextAsync())
+                {
+                    count++;
+
+                    // Convert JObject to JsonElement.
+                    string jsonString = item.ToString(Newtonsoft.Json.Formatting.None);
+                    JsonElement element = JsonDocument.Parse(jsonString).RootElement;
+
+                    // Try posting the detection to Orcasite.
+                    // This will fail if it is already present there.
+                    var documents = new List<JsonElement> { element };
+                    bool ok = await postToOrcasite.ProcessDocumentsAsync(documents);
+                    if (ok)
+                    {
+                        successes++;
+                    }
+
+                    // Output the result.
+                    string timestamp = element.GetProperty("timestamp").GetDateTime().ToString();
+                    Console.WriteLine($"#{count}: Posting {timestamp} => {ok}");
+                }
+            }
+
+            Console.WriteLine($"Total items read: {count}");
+        }
+    }
+}

--- a/NotificationSystem/README.md
+++ b/NotificationSystem/README.md
@@ -1,6 +1,6 @@
 ## AI For Orcas - Notification System
 
-The notification system is a set of azure functions responsible for:
+The notification system is a set of Azure functions responsible for:
 - Facilitating adding/removing moderators and subscribers
 - Identifying changes in the database and sending alerts
 
@@ -150,3 +150,14 @@ Create local.settings.json in the current directory (NotificationSystem) using t
 1. Go to the "orcanotification" function app (link 3 above). 
 2. On the "Overview" tab, make sure the status of the function shows running.
 3. On the "Functions" tab, you should see all the functions of the notification system. Enable/Disable as needed.
+
+## Directory structure
+
+The directories in this system are organized as follows:
+
+* img: Contains images used in this README
+* NotificationSystem: Contains the source code for the Azure functions
+* NotificationSystem.Tests.Unit: Contains unit tests
+* NotificationSystem.Tests.Integration: Contains integration tests
+* PostBackfillToOrcasite: Contains a console app to post the history of machine detections to the Orcasite detection API
+* TestData: Contains data files used by the tests


### PR DESCRIPTION
PR #250 added functionality to publish _new_ detections to Orcasite, but not historical detections.
This should be done in this new standalone utility that can be manually run.
Having all detections (human and machine) in one database allows new types of historical research to be done, as discussed in Orcasite meetings.

This has been tested by posting to **beta.orcasound.net** all AI detections since July 30, 2025.  (According to Skander the beta site only has audio data newer than that so will only accept historical detections since then.)  Testing verified that:
1.  Any detections without data on beta.orcasound.net get ignored.  (Ones at the very start of the period.)
2. Newer detections get published there if not already present.
3. If already present, any duplicate detections are ignored (e.g., recent ones since PR #250 went live).

Fixes #260 