### PR TITLE
Enable NotificationSystem integration test to run in github CI/CD

### DIFF
--- a/.github/workflows/NotificationSystem.yaml
+++ b/.github/workflows/NotificationSystem.yaml
@@ -21,7 +21,6 @@ env:
   WORKING_DIR: NotificationSystem/NotificationSystem
   PUBLISH_DIR: output
   AZURE_APP_NAME: orcanotification
-  aifororcasmetadatastore_DOCUMENTDB: ${{ secrets.AIFORORCASMETADATASTORE_DOCUMENTDB }}
 
 defaults:
   run:

--- a/.github/workflows/NotificationSystem.yaml
+++ b/.github/workflows/NotificationSystem.yaml
@@ -21,6 +21,7 @@ env:
   WORKING_DIR: NotificationSystem/NotificationSystem
   PUBLISH_DIR: output
   AZURE_APP_NAME: orcanotification
+  aifororcasmetadatastore_DOCUMENTDB: ${{ secrets.AIFORORCASMETADATASTORE_DOCUMENTDB }}
 
 defaults:
   run:

--- a/NotificationSystem/NotificationSystem.Tests.Unit/OrcasiteTestHelper.cs
+++ b/NotificationSystem/NotificationSystem.Tests.Unit/OrcasiteTestHelper.cs
@@ -50,12 +50,6 @@ namespace NotificationSystem.Tests.Common
             return File.ReadAllText(Path.Combine(solutionDirectory, "TestData", filename));
         }
 
-        public static OrcasiteHelper GetMockOrcasiteHelper(ILogger<OrcasiteHelper> logger)
-        {
-            var container = GetMockOrcasiteHelperWithRequestVerification(logger);
-            return container.Helper;
-        }
-
         /// <summary>
         /// Get a mock OrcasiteHelper along with the MockHttpMessageHandler for verification.
         /// </summary>

--- a/NotificationSystem/PostBackfillToOrcasite/Program.cs
+++ b/NotificationSystem/PostBackfillToOrcasite/Program.cs
@@ -102,6 +102,7 @@ Example:
             }
 
             Console.WriteLine($"Total items read: {count}");
+            Console.WriteLine($"Total items posted: {successes}");
         }
     }
 }


### PR DESCRIPTION
 Currently it shows up as skipped because the connection string to use is not configured, but the connection string was not in fact used for anything.

Also removed UpdateCosmosDb_WithDependencyInjection since it did the same thing as PostToOrcasite_ProcessDocumentsAsync.

After this change:
> **Passed**!  - Failed:     0, **Passed:     1**, Skipped:     0, Total:     1, Duration: 230 ms - NotificationSystem.Tests.Integration.dll (net8.0)

Fixes #286