### PR TITLE
Fix timestamps before posting to orcasite

### DIFF
--- a/NotificationSystem/NotificationSystem/NotificationSystem.csproj
+++ b/NotificationSystem/NotificationSystem/NotificationSystem.csproj
@@ -6,6 +6,7 @@
     <UserSecretsId>8b84a2b2-204f-4152-85e4-8860e457738c</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="AWSSDK.S3" Version="4.0.7.4" />
     <PackageReference Include="AWSSDK.SimpleEmail" Version="4.0.1.2" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.23.0" />
   <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.53.1" />

--- a/NotificationSystem/NotificationSystem/PostToOrcasite.cs
+++ b/NotificationSystem/NotificationSystem/PostToOrcasite.cs
@@ -5,6 +5,7 @@ using NotificationSystem.Models;
 using RateLimiter;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.Eventing.Reader;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -66,7 +67,12 @@ namespace NotificationSystem
                 LeaseContainerPrefix = "orcasite",
                 CreateLeaseContainerIfNotExists = true)] IReadOnlyList<JsonElement> input)
         {
-            bool ok = await ProcessDocumentsAsync(input);
+            // Currently all data in the OrcaHello database has incorrect timestamps.
+            // We correct for that here.
+            // TODO(issue #219): Remove this workaround when the data is fixed.
+            IReadOnlyList<JsonElement> correctedInput = await _helper.FixTimestampsAsync(input);
+
+            bool ok = await ProcessDocumentsAsync(correctedInput);
             if (ok)
             {
                 Interlocked.Increment(ref _successfulRuns);

--- a/NotificationSystem/PostBackfillToOrcasite/Program.cs
+++ b/NotificationSystem/PostBackfillToOrcasite/Program.cs
@@ -89,7 +89,13 @@ Example:
                     // Try posting the detection to Orcasite.
                     // This will fail if it is already present there.
                     var documents = new List<JsonElement> { element };
-                    bool ok = await postToOrcasite.ProcessDocumentsAsync(documents);
+
+                    // Currently all data in the OrcaHello database has incorrect timestamps.
+                    // We correct for that here.
+                    // TODO(issue #219): Update this workaround when the data is fixed.
+                    IReadOnlyList<JsonElement> correctedDocuments = await orcasiteHelper.FixTimestampsAsync(documents);
+
+                    bool ok = await postToOrcasite.ProcessDocumentsAsync(correctedDocuments);
                     if (ok)
                     {
                         successes++;


### PR DESCRIPTION
This PR does two things:
1) Updates the backfill tool to send corrected timestamps to Orcasite
2) Updates the NotificationSystem to send corrected timestamps to Orcasite for new detections.  This latter part will go away once the HLS fix in https://github.com/orcasound/orca-hls-utils/pull/24 is incorporated into the InferenceSystem so that the OrcaHello timestamps are correct to begin with.  TODO comments are in the code to remove the workaround as part of doing that step.

Addresses part of #219.  Addressing the rest of that issue requires the orca-hls-utils PR to be merged first so it can be consumed from this repository.