### PR TITLE
Let dependabot check InferenceSystem dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,10 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
+  - package-ecosystem: "pip"
+    directory: "/InferenceSystem"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+    allow:
+      - dependency-type: "direct"

--- a/InferenceSystem/requirements.txt
+++ b/InferenceSystem/requirements.txt
@@ -3,11 +3,11 @@ fastai==1.0.61
 librosa==0.8.0
 pydub==0.24.1
 pandas
-numpy
+numpy==1.21.6
 torchaudio==0.6.0
 git+https://github.com/fastaudio/fastai_audio@0.1
 ipython
-spacy
+spacy==3.5.4
 awscli
 requests
 bs4


### PR DESCRIPTION
Some current dependencies have problems in that InferenceSystem scripts relies on some functionality that has been removed in later versions, so requirements.txt must currently pin such dependencies to an older version, which this PR does for numpy and spacy.  Without that fix, the README instructions fail.

As noted in issue #211 there is currently no notification when there is a problem like this since there's no CI workflows for the InferenceSystem yet, and no dependabot checks.  This PR adds dependabot checks.  A separate PR will add a CI workflow.