### PR TITLE
Update InferenceSystem dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,13 @@ updates:
       day: "saturday"
     allow:
       - dependency-type: "direct"
+    groups:
+      pip-dependencies:
+        patterns:
+          - "*"
+    labels:
+      - "inference system"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
Similar to NotificationSystem config:
* Ignore major version changes as they may be breaking changes
* Group all dependency updates into a single PR
* Add the "inference system" label on such PRs