### PR TITLE
Add Andrews Bay hydrophone

### DIFF
--- a/InferenceSystem/config/Production/FastAI_LiveHLS_AndrewsBay.yml
+++ b/InferenceSystem/config/Production/FastAI_LiveHLS_AndrewsBay.yml
@@ -1,0 +1,10 @@
+model_type: "FastAI"
+model_local_threshold: 0.5
+model_global_threshold: 3
+model_path: "./model"
+model_name: "model.pkl"
+hls_stream_type: "LiveHLS"
+hls_polling_interval: 60
+hls_hydrophone_id: "rpi_andrews_bay"
+upload_to_azure: True
+delete_local_wavs: True

--- a/InferenceSystem/demos/hls_reader.py
+++ b/InferenceSystem/demos/hls_reader.py
@@ -19,6 +19,7 @@ import spectrogram_visualizer
 
 # TODO: get the list from https://live.orcasound.net/api/json/feeds
 ORCASOUND_STREAMS = {
+    'AndrewsBay': 'https://s3-us-west-2.amazonaws.com/audio-orcasound-net/rpi_andrews_bay',
     'BushPoint': 'https://s3-us-west-2.amazonaws.com/audio-orcasound-net/rpi_bush_point',
     'MaSTCenter': 'https://s3-us-west-2.amazonaws.com/audio-orcasound-net/rpi_mast_center',
     'NorthSanJuanChannel': 'https://s3-us-west-2.amazonaws.com/audio-orcasound-net/rpi_north_sjc',

--- a/InferenceSystem/deploy/andrews-bay.yaml
+++ b/InferenceSystem/deploy/andrews-bay.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inference-system
+  namespace: andrews-bay
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: inference-system
+  template:
+    metadata:
+      labels:
+        app: inference-system
+    spec:
+      containers:
+      - name: inference-system
+        image: orcaconservancycr.azurecr.io/live-inference-system:09-18-24.FastAI.R1-12.AndrewsBay.v0
+        resources:
+          limits:
+            cpu: 1
+            memory: 3G
+        env:
+          - name: AZURE_COSMOSDB_PRIMARY_KEY
+            valueFrom:
+              secretKeyRef:
+                name: inference-system
+                key: AZURE_COSMOSDB_PRIMARY_KEY
+          - name: AZURE_STORAGE_CONNECTION_STRING
+            valueFrom:
+              secretKeyRef:
+                name: inference-system
+                key: AZURE_STORAGE_CONNECTION_STRING
+          - name: INFERENCESYSTEM_APPINSIGHTS_CONNECTION_STRING
+            valueFrom:
+              secretKeyRef:
+                name: inference-system
+                key: INFERENCESYSTEM_APPINSIGHTS_CONNECTION_STRING

--- a/InferenceSystem/src/LiveInferenceOrchestrator.py
+++ b/InferenceSystem/src/LiveInferenceOrchestrator.py
@@ -34,6 +34,7 @@ COSMOSDB_DATABASE_NAME = "predictions"
 COSMOSDB_CONTAINER_NAME = "metadata"
 
 # TODO: get this data from https://live.orcasound.net/api/json/feeds
+ANDREWS_BAY_LOCATION = {"id": "rpi_andrews_bay", "name": "Andrews Bay", "longitude":  -123.1666492, "latitude": 48.5500299}
 BUSH_POINT_LOCATION = {"id": "rpi_bush_point", "name": "Bush Point", "longitude":  -122.6040035, "latitude": 48.0336664}
 MAST_CENTER_LOCATION = {"id": "rpi_mast_center", "name": "Mast Center", "longitude":  -122.32512, "latitude": 47.34922}
 NORTH_SAN_JUAN_CHANNEL_LOCATION = {"id": "rpi_north_sjc", "name": "North San Juan Channel", "longitude":  -123.058779, "latitude": 48.591294}
@@ -42,7 +43,7 @@ POINT_ROBINSON_LOCATION = {"id": "rpi_point_robinson", "name": "Point Robinson",
 PORT_TOWNSEND_LOCATION = {"id": "rpi_port_townsend", "name": "Port Townsend", "longitude":  -122.760614, "latitude": 48.135743}
 SUNSET_BAY_LOCATION = {"id": "rpi_sunset_bay", "name": "Sunset Bay", "longitude":  -122.33393605795372, "latitude": 47.86497296593844}
 
-source_guid_to_location = {"rpi_bush_point": BUSH_POINT_LOCATION, "rpi_mast_center": MAST_CENTER_LOCATION, "rpi_north_sjc": NORTH_SAN_JUAN_CHANNEL_LOCATION, "rpi_orcasound_lab" : ORCASOUND_LAB_LOCATION, "rpi_point_robinson": POINT_ROBINSON_LOCATION, "rpi_port_townsend" : PORT_TOWNSEND_LOCATION, "rpi_sunset_bay": SUNSET_BAY_LOCATION}
+source_guid_to_location = {"rpi_andrews_bay": ANDREWS_BAY_LOCATION, "rpi_bush_point": BUSH_POINT_LOCATION, "rpi_mast_center": MAST_CENTER_LOCATION, "rpi_north_sjc": NORTH_SAN_JUAN_CHANNEL_LOCATION, "rpi_orcasound_lab" : ORCASOUND_LAB_LOCATION, "rpi_point_robinson": POINT_ROBINSON_LOCATION, "rpi_port_townsend" : PORT_TOWNSEND_LOCATION, "rpi_sunset_bay": SUNSET_BAY_LOCATION}
 
 def assemble_blob_uri(container_name, item_name):
 

--- a/InferenceSystem/src/PrepareDataForPredictionExplorer.py
+++ b/InferenceSystem/src/PrepareDataForPredictionExplorer.py
@@ -205,7 +205,7 @@ def main():
         help="End time in PST in following format 2020-07-25 20:15")
     # TODO: get list of streams from https://live.orcasound.net/api/json/feeds instead of hard coding it
     parser.add_argument("--s3_stream", type=str, required=True, \
-        help="Hydrophone stream (bush_point/mast_center/north_sjc/orcasound_lab/point_robinson/port_townsend/sunset_bay)")
+        help="Hydrophone stream (andrews_bay/bush_point/mast_center/north_sjc/orcasound_lab/point_robinson/port_townsend/sunset_bay)")
     parser.add_argument("--model_path", type=str, required=True, \
         help="Path to the model folder that contains weights and mean, invstd")
     parser.add_argument("--annotation_threshold", type=float, required=True, \

--- a/InferenceSystem/src/globals.py
+++ b/InferenceSystem/src/globals.py
@@ -1,6 +1,7 @@
 import datetime
 
 S3_STREAM_URLS = {
+    "andrews_bay": "https://s3-us-west-2.amazonaws.com/audio-orcasound-net/rpi_andrews_bay",
     "bush_point": "https://s3-us-west-2.amazonaws.com/audio-orcasound-net/rpi_bush_point",
     "mast_center": "https://s3-us-west-2.amazonaws.com/audio-orcasound-net/rpi_mast_center",
     "north_sjc": "https://s3-us-west-2.amazonaws.com/audio-orcasound-net/rpi_north_sjc",

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/appsettings.Development.json
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/appsettings.Development.json
@@ -9,7 +9,7 @@
   },
   "AppSettings": {
     "APIUrl": "https://apisitename.azurewebsites.net/",
-    "Locations": [ "Bush Point", "MaST Center", "North San Juan Channel", "Orcasound Lab", "Point Robinson", "Port Townsend", "Sunset Bay" ],
+    "Locations": [ "Andrews Bay", "Bush Point", "MaST Center", "North San Juan Channel", "Orcasound Lab", "Point Robinson", "Port Townsend", "Sunset Bay" ],
     "AzureAd": {
       "Instance": "https://login.microsoftonline.com/",
       "Domain": "outlookdomain.onmicrosoft.com",

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/appsettings.json
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/appsettings.json
@@ -23,7 +23,7 @@
   "AllowedHosts": "*",
   "AppSettings": {
     "APIUrl": "https://apisitename.azurewebsites.net/",
-    "Locations": [ "Bush Point", "MaST Center", "North San Juan Channel", "Orcasound Lab", "Point Robinson", "Port Townsend", "Sunset Bay" ],
+    "Locations": [ "Andrews Bay", "Bush Point", "MaST Center", "North San Juan Channel", "Orcasound Lab", "Point Robinson", "Port Townsend", "Sunset Bay" ],
     "AzureAd": {
       "Instance": "https://login.microsoftonline.com/",
       "Domain": "outlookdomain.onmicrosoft.com",


### PR DESCRIPTION
In preparation for new hydrophone deployment at Andrews Bay within the next month or so.

Currently the RPI is streaming silence to the
dev-streaming-orcasound.net bucket instead of the audio-orcasound-net bucket.  The bucket will need to change to audio-orcasound-net before this PR can be successfully tested.  Will leave in Draft until then.